### PR TITLE
Added/fixed Midsummer Day

### DIFF
--- a/holidays/plan2/holiday_lv_lv
+++ b/holidays/plan2/holiday_lv_lv
@@ -37,8 +37,8 @@ language    "lv"
                                                                                  noop )
 : Midsummers Eve
 "Līgo Diena"                                                        public on june 23
-: Midsummers Eve
-"Jāņi"                                                              public on june 23
+: Midsummer Day
+"Jāņi"                                                              public on june 24
 : Proclamation of the Republic of Latvia
 "Latvijas Republikas proklamēšanas diena"                           public on november 18
 "Latvijas Republikas proklamēšanas diena"                           public on ( ( ( [november 18] == [saturday after ([november 18])] ) ||


### PR DESCRIPTION
As mentioned in https://en.wikipedia.org/wiki/Public_holidays_in_Latvia - "Jāņi" in Latvia is celebrated on 24th June.