### PR TITLE
Add holiday file for Guyana

### DIFF
--- a/holidays/holidays.qrc
+++ b/holidays/holidays.qrc
@@ -73,6 +73,7 @@
         <file>plan2/holiday_gr_el</file>
         <file>plan2/holiday_gr_el_nameday</file>
         <file>plan2/holiday_gt_es</file>
+        <file>plan2/holiday_gy_en-gb</file>
         <file>plan2/holiday_hk_en-gb</file>
         <file>plan2/holiday_hk_zh-cn</file>
         <file>plan2/holiday_hr_hr</file>


### PR DESCRIPTION
Noticed that Holidays for Guyana was missing in the Holidays Tab of the Calendar app on the Plasma Desktop. I have proposed the holiday_gy_en-gb file in plan2/ in a previous pull request. I propose this entry for the file. I do not know the procedures for testing.